### PR TITLE
fix: update isbinaryfile to fix an issue with protobuf parsing causing hanging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"common-path-prefix": "^3.0.0",
 				"cross-fetch": "^3.2.0 <4",
 				"ignore": "^7.0.4",
-				"isbinaryfile": "^4.0.10 <5",
+				"isbinaryfile": "^5.0.6 <6",
 				"js-yaml": "^4.1.0",
 				"node-cache": "^5.1.2"
 			},
@@ -108,11 +108,12 @@
 			}
 		},
 		"node_modules/isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"version": "5.0.6",
+			"resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/isbinaryfile/-/isbinaryfile-5.0.6.tgz",
+			"integrity": "sha512-I+NmIfBHUl+r2wcDd6JwE9yWje/PIVY/R5/CmV8dXLZd5K+L9X2klAOwfAHNnondLXkbHyTAleQAWonpTJBTtw==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 8.0.0"
+				"node": ">= 18.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/gjtorikian/"
@@ -259,9 +260,9 @@
 			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A=="
 		},
 		"isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="
+			"version": "5.0.6",
+			"resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/isbinaryfile/-/isbinaryfile-5.0.6.tgz",
+			"integrity": "sha512-I+NmIfBHUl+r2wcDd6JwE9yWje/PIVY/R5/CmV8dXLZd5K+L9X2klAOwfAHNnondLXkbHyTAleQAWonpTJBTtw=="
 		},
 		"js-yaml": {
 			"version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"common-path-prefix": "^3.0.0",
 		"cross-fetch": "^3.2.0 <4",
 		"ignore": "^7.0.4",
-		"isbinaryfile": "^4.0.10 <5",
+		"isbinaryfile": "^5.0.6 <6",
 		"js-yaml": "^4.1.0",
 		"node-cache": "^5.1.2"
 	},


### PR DESCRIPTION
We are using this package to analyze repositories in order to determine the languages used. Some repositories will hang while processing. This is caused by a bug in the isbinaryfile package in the way it processes files to determine if the file is a protobuf. This package also had a bug in how it handled errors in a callback when promises were used. Both of these bugs were fixed and published in `5.0.5` and `5.0.6`.

- <https://github.com/gjtorikian/isBinaryFile/pull/86>
- <https://github.com/gjtorikian/isBinaryFile/pull/85>

NPM versions: <https://www.npmjs.com/package/isbinaryfile?activeTab=versions>

This PR updates `isbinaryfile` to `5.0.6`.